### PR TITLE
Formal Method, Type Theory: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,18 @@ The interdisciplinary of Mathematics and Computer Science; It is distinguished b
   - [Computability Theory](#theory_of_computation_computability_theory)
     - [Books](#theory_of_computation_computability_theory_books)
       - [Introductory](#theory_of_computation_computability_theory_books_introductory) | [Advanced](#theory_of_computation_computability_theory_books_advanced) | [Monograph](#theory_of_computation_computability_theory_books_monograph)
+- [Programming Language Theory](#programming_language_theory)
+  - [Basics](#programming_language_theory_basics)
+    - [Books](#programming_language_theory_basics_books)
+  - [Formal Verification](#programming_language_theory_formal_verification)
+    - [Lecture Notes](#programming_language_theory_formal_verification_lecture_notes) | [Books](#programming_language_theory_formal_verification_books)
+  - [Type Theory](#programming_language_theory_type_theory)
+    - [Lecture Notes](#programming_language_theory_type_theory_lecture_notes) | [Books](#programming_language_theory_type_theory_books) | [Others](#programming_language_theory_type_theory_others)
+  - [Functional Programming](#programming_language_theory_functional_programming)
+    - [Lecture Notes](#programming_language_theory_functional_programming_lecture_notes)
 - [Logic](#logic)
   - [Computational Complexity](#logic_computational_complexity)
     - [Books](#logic_computational_complexity_books)
-  - [Formal Method](#logic_formal_method)
-    - [Lecture Notes](#logic_formal_method_lecture_notes) | [Books](#logic_formal_method_books)
 - [Algorithms](#algorithms)
   - [General](#algorithms_general)
     - [Lecture Notes](#algorithms_general_lecture_notes) | [Books](#algorithms_general_books)
@@ -61,7 +68,6 @@ The interdisciplinary of Mathematics and Computer Science; It is distinguished b
   - [Discrete Mathematics](#mathlogic_preliminaries_discrete_mathematics)
     - [Lecture Notes](#mathlogic_preliminaries_discrete_mathematics_lecture_notes) | [Books](#mathlogic_preliminaries_discrete_mathematics_books) | [MOOC](#mathlogic_preliminaries_discrete_mathematics_mooc)
   - [Transition To Pure Rigour Math](#mathlogic_preliminaries_transition_to_pure_rigour_math)
-  - [Type Theory](#mathlogic_preliminaries_type_theory)
 - [Surveys & Monographs](#surveys__monographs)
 - [Live Content](#live_content)
   - [Conferences, Workshops, Events, and Talks](#live_content_conferences_workshops_events_and_talks)
@@ -144,16 +150,34 @@ The interdisciplinary of Mathematics and Computer Science; It is distinguished b
 - [Odifreddi. Classical Recursion Theory: The Theory of Functions and Sets of Natural Numbers](https://archive.org/details/classicalrecursi0000odif) - An impressive presentation of classical recursion theory. It is highly recommended to everyone interested in recursion theory.
 #### Monograph<a name=theory_of_computation_computability_theory_books_monograph></a>
 - [Copeland, Posy & Shagrir (editors). Computability: Turing, Gödel, Church, and Beyond](https://mitpress.mit.edu/books/computability) - Computer scientists, mathematicians, and philosophers discuss the conceptual foundations of the notion of computability as well as recent theoretical developments.
+# Programming Language Theory<a name=programming_language_theory></a>
+## Basics<a name=programming_language_theory_basics></a>
+### Books<a name=programming_language_theory_basics_books></a>
+- [Structure and Interpretation of Computer Programs](https://mitp-content-server.mit.edu/books/content/sectbyfn/books_pres_0/6515/sicp.zip/index.html) - a computer science textbook teaching fundamental principles of computer programming in Scheme, including recursion, abstraction, modularity, and programming language design and implementation.
+- [Structure and Interpretation of Computer Programs, Javascript version](https://sourceacademy.org/sicpjs/index) - SICP rewritten in Javascript
+## Formal Verification<a name=programming_language_theory_formal_verification></a>
+### Lecture Notes<a name=programming_language_theory_formal_verification_lecture_notes></a>
+- [UW CSE505 18au Principles of PL](https://sites.google.com/cs.washington.edu/cse-505-18au/home) - Techniques for thinking crisply about programming languages, write some fascinating programs, and discuss various design tradeoffs.
+### Books<a name=programming_language_theory_formal_verification_books></a>
+- [Pierce. Software Foundations](https://softwarefoundations.cis.upenn.edu/) - A broad introduction series to the mathematical underpinnings of reliable software with Coq proof assistant. It's intended for a broad range of readers, with no specific background assumed.
+- [Chlipala. Formal Reasoning About Programs](http://adam.chlipala.net/frap) - A book introducing both machine-checked proof with Coq Proof Assistant and approaches to formal reasoning about program correctness.
+- [Lean Community. Logic and Proof](https://leanprover.github.io/logic_and_proof) - Introduction to logic and proof with Lean Proof Assistant.
+## Type Theory<a name=programming_language_theory_type_theory></a>
+### Lecture Notes<a name=programming_language_theory_type_theory_lecture_notes></a>
+- [Martin-Löf. Intuitionistic Type Theory](https://raw.githubusercontent.com/michaelt/martin-lof/master/pdfs/Bibliopolis-Book-retypeset-1984.pdf) - Notes by Giovanni Sambin of a series of type theory lectures given in Padua, June 1980.
+### Books<a name=programming_language_theory_type_theory_books></a>
+- [Bengt. Programming in Martin-Löf's Type Theory](https://www.cse.chalmers.se/research/group/logic/book/book.pdf) - This book describes different type theories (theories of types, polymorphic and monomorphic sets, and subsets) from a computing science perspective.
+- [The Univalent Foundations Program Institute for Advanced Study. Homotopy Type Theory: Univalent Foundations of Mathematics](https://homotopytypetheory.org/book) - The present book is intended as a first systematic exposition of the basics of univalent foundations, and a collection of examples of this new style of reasoning — but without requiring the reader to know or learn any formal logic, or to use any computer proof assistant.
+### Others<a name=programming_language_theory_type_theory_others></a>
+- [Type Theory in nLab](https://ncatlab.org/nlab/show/type+theory) - A curated list of mathematics including type theory and proof assistants.
+## Functional Programming<a name=programming_language_theory_functional_programming></a>
+### Lecture Notes<a name=programming_language_theory_functional_programming_lecture_notes></a>
+- [University of Helsinki. Haskell MOOC](https://haskell.mooc.fi) - An online course on functional programming that uses the Haskell programming language.
+- [Cornell. Functional Programming in Ocaml](https://www.cs.cornell.edu/courses/cs3110/2024sp) - A course on data structures and functional programming using OCaml.
 # Logic<a name=logic></a>
 ## Computational Complexity<a name=logic_computational_complexity></a>
 ### Books<a name=logic_computational_complexity_books></a>
 - [Pudlák. Logical Foundations of Mathematics and Computational Complexity: A Gentle Introduction](https://www.springer.com/gp/book/9783319001180) - Presents a wide range of results in logic and computational complexity.
-## Formal Method<a name=logic_formal_method></a>
-### Lecture Notes<a name=logic_formal_method_lecture_notes></a>
-- [UW CSE505 18au Principles of PL](https://sites.google.com/cs.washington.edu/cse-505-18au/home) - Techniques for thinking crisply about programming languages, write some fascinating programs, and discuss various design tradeoffs.
-### Books<a name=logic_formal_method_books></a>
-- [Chlipala. Formal Reasoning About Programs](http://adam.chlipala.net/frap/) - A book introducing both machine-checked proof with the Coq proof assistant and approaches to formal reasoning about program correctness.
-- [Pierce. Software Foundations Vol.1 Logical Foundation](https://softwarefoundations.cis.upenn.edu/lf-current/index.html) - Introduction to the mathematical underpinnings of reliable software with Coq Proof Assistant.
 # Algorithms<a name=algorithms></a>
 ## General<a name=algorithms_general></a>
 ### Lecture Notes<a name=algorithms_general_lecture_notes></a>
@@ -308,10 +332,6 @@ The interdisciplinary of Mathematics and Computer Science; It is distinguished b
 - [Introduction to Discrete Mathematics for Computer Science. UC San-Diego](https://www.coursera.org/specializations/discrete-mathematics) - Learn the language of Computer Science. Learn the math that defines computer science, and practice applying it through mathematical proofs and Python code.
 ## Transition To Pure Rigour Math<a name=mathlogic_preliminaries_transition_to_pure_rigour_math></a>
 - Velleman. How to Prove it: A Structured Approach. - It transitions from solving problems to proving theorems by teaching them the techniques needed to read and write proofs.
-## Type Theory<a name=mathlogic_preliminaries_type_theory></a>
-- [Daniel Gratzer. learn-type-theory](https://github.com/jozefg/learn-tt) - A collection of resources for learning type theory and type theory adjacent fields.
-- [Type Theory in nLab](https://ncatlab.org/nlab/show/type+theory)
-- [Infinity-Type-Cafe. ∞-type Café Summer School](https://infinity-type-cafe.github.io/ntype-cafe-summer-school/) - A summer school on type theory (written in Chinese)
 # Surveys & Monographs<a name=surveys__monographs></a>
 - [Sommaruga & Strahm. Turing’s Revolution: The Impact of His Ideas about Computability](https://link.springer.com/book/10.1007/978-3-319-22156-4) - A collection of historical, technical and philosophical papers.
 - [Harry Lewis. Ideas That Created the Future: Classic Papers of Computer Science ](https://mitpress.mit.edu/9780262045308/ideas-that-created-the-future/) - Classic papers by thinkers ranging from Aristotle and Leibniz to Norbert Wiener and Gordon Moore that chart the evolution of computer science.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The interdisciplinary of Mathematics and Computer Science; It is distinguished b
 - [Logic](#logic)
   - [Computational Complexity](#logic_computational_complexity)
     - [Books](#logic_computational_complexity_books)
+  - [Formal Method](#logic_formal_method)
+    - [Lecture Notes](#logic_formal_method_lecture_notes) | [Books](#logic_formal_method_books)
 - [Algorithms](#algorithms)
   - [General](#algorithms_general)
     - [Lecture Notes](#algorithms_general_lecture_notes) | [Books](#algorithms_general_books)
@@ -59,6 +61,7 @@ The interdisciplinary of Mathematics and Computer Science; It is distinguished b
   - [Discrete Mathematics](#mathlogic_preliminaries_discrete_mathematics)
     - [Lecture Notes](#mathlogic_preliminaries_discrete_mathematics_lecture_notes) | [Books](#mathlogic_preliminaries_discrete_mathematics_books) | [MOOC](#mathlogic_preliminaries_discrete_mathematics_mooc)
   - [Transition To Pure Rigour Math](#mathlogic_preliminaries_transition_to_pure_rigour_math)
+  - [Type Theory](#mathlogic_preliminaries_type_theory)
 - [Surveys & Monographs](#surveys__monographs)
 - [Live Content](#live_content)
   - [Conferences, Workshops, Events, and Talks](#live_content_conferences_workshops_events_and_talks)
@@ -145,6 +148,12 @@ The interdisciplinary of Mathematics and Computer Science; It is distinguished b
 ## Computational Complexity<a name=logic_computational_complexity></a>
 ### Books<a name=logic_computational_complexity_books></a>
 - [Pudlák. Logical Foundations of Mathematics and Computational Complexity: A Gentle Introduction](https://www.springer.com/gp/book/9783319001180) - Presents a wide range of results in logic and computational complexity.
+## Formal Method<a name=logic_formal_method></a>
+### Lecture Notes<a name=logic_formal_method_lecture_notes></a>
+- [UW CSE505 18au Principles of PL](https://sites.google.com/cs.washington.edu/cse-505-18au/home) - Techniques for thinking crisply about programming languages, write some fascinating programs, and discuss various design tradeoffs.
+### Books<a name=logic_formal_method_books></a>
+- [Chlipala. Formal Reasoning About Programs](http://adam.chlipala.net/frap/) - A book introducing both machine-checked proof with the Coq proof assistant and approaches to formal reasoning about program correctness.
+- [Pierce. Software Foundations Vol.1 Logical Foundation](https://softwarefoundations.cis.upenn.edu/lf-current/index.html) - Introduction to the mathematical underpinnings of reliable software with Coq Proof Assistant.
 # Algorithms<a name=algorithms></a>
 ## General<a name=algorithms_general></a>
 ### Lecture Notes<a name=algorithms_general_lecture_notes></a>
@@ -299,6 +308,10 @@ The interdisciplinary of Mathematics and Computer Science; It is distinguished b
 - [Introduction to Discrete Mathematics for Computer Science. UC San-Diego](https://www.coursera.org/specializations/discrete-mathematics) - Learn the language of Computer Science. Learn the math that defines computer science, and practice applying it through mathematical proofs and Python code.
 ## Transition To Pure Rigour Math<a name=mathlogic_preliminaries_transition_to_pure_rigour_math></a>
 - Velleman. How to Prove it: A Structured Approach. - It transitions from solving problems to proving theorems by teaching them the techniques needed to read and write proofs.
+## Type Theory<a name=mathlogic_preliminaries_type_theory></a>
+- [Daniel Gratzer. learn-type-theory](https://github.com/jozefg/learn-tt) - A collection of resources for learning type theory and type theory adjacent fields.
+- [Type Theory in nLab](https://ncatlab.org/nlab/show/type+theory)
+- [Infinity-Type-Cafe. ∞-type Café Summer School](https://infinity-type-cafe.github.io/ntype-cafe-summer-school/) - A summer school on type theory (written in Chinese)
 # Surveys & Monographs<a name=surveys__monographs></a>
 - [Sommaruga & Strahm. Turing’s Revolution: The Impact of His Ideas about Computability](https://link.springer.com/book/10.1007/978-3-319-22156-4) - A collection of historical, technical and philosophical papers.
 - [Harry Lewis. Ideas That Created the Future: Classic Papers of Computer Science ](https://mitpress.mit.edu/9780262045308/ideas-that-created-the-future/) - Classic papers by thinkers ranging from Aristotle and Leibniz to Norbert Wiener and Gordon Moore that chart the evolution of computer science.

--- a/big_list_builder/source.json
+++ b/big_list_builder/source.json
@@ -101,23 +101,53 @@
         }
     },
 
+    "Programming Language Theory": {
+        "Basics": {
+            "Books": [
+                "[Structure and Interpretation of Computer Programs](https://mitp-content-server.mit.edu/books/content/sectbyfn/books_pres_0/6515/sicp.zip/index.html) - a computer science textbook teaching fundamental principles of computer programming in Scheme, including recursion, abstraction, modularity, and programming language design and implementation.",
+                "[Structure and Interpretation of Computer Programs, Javascript version](https://sourceacademy.org/sicpjs/index) - SICP rewritten in Javascript"
+            ]
+        },
+
+        "Formal Verification": {
+            "Lecture Notes": [
+                "[UW CSE505 18au Principles of PL](https://sites.google.com/cs.washington.edu/cse-505-18au/home) - Techniques for thinking crisply about programming languages, write some fascinating programs, and discuss various design tradeoffs."
+            ],
+            "Books": [
+                "[Pierce. Software Foundations](https://softwarefoundations.cis.upenn.edu/) - A broad introduction series to the mathematical underpinnings of reliable software with Coq proof assistant. It's intended for a broad range of readers, with no specific background assumed.",
+                "[Chlipala. Formal Reasoning About Programs](http://adam.chlipala.net/frap) - A book introducing both machine-checked proof with Coq Proof Assistant and approaches to formal reasoning about program correctness.",
+                "[Lean Community. Logic and Proof](https://leanprover.github.io/logic_and_proof) - Introduction to logic and proof with Lean Proof Assistant."
+            ]
+        },
+
+        "Type Theory": {
+            "Lecture Notes": [
+                "[Martin-Löf. Intuitionistic Type Theory](https://raw.githubusercontent.com/michaelt/martin-lof/master/pdfs/Bibliopolis-Book-retypeset-1984.pdf) - Notes by Giovanni Sambin of a series of type theory lectures given in Padua, June 1980."
+            ],
+            "Books": [
+                "[Bengt. Programming in Martin-Löf's Type Theory](https://www.cse.chalmers.se/research/group/logic/book/book.pdf) - This book describes different type theories (theories of types, polymorphic and monomorphic sets, and subsets) from a computing science perspective.",
+                "[The Univalent Foundations Program Institute for Advanced Study. Homotopy Type Theory: Univalent Foundations of Mathematics](https://homotopytypetheory.org/book) - The present book is intended as a first systematic exposition of the basics of univalent foundations, and a collection of examples of this new style of reasoning — but without requiring the reader to know or learn any formal logic, or to use any computer proof assistant."
+            ],
+            "Others": [
+                "[Type Theory in nLab](https://ncatlab.org/nlab/show/type+theory) - A curated list of mathematics including type theory and proof assistants."
+            ]
+        },
+    
+        "Functional Programming": {
+            "Lecture Notes": [
+                "[University of Helsinki. Haskell MOOC](https://haskell.mooc.fi) - An online course on functional programming that uses the Haskell programming language.",
+                "[Cornell. Functional Programming in Ocaml](https://www.cs.cornell.edu/courses/cs3110/2024sp) - A course on data structures and functional programming using OCaml."
+            ]
+        }
+    },
+
     "Logic": {
         "Computational Complexity": {
             "Books": [
                 "[Pudlák. Logical Foundations of Mathematics and Computational Complexity: A Gentle Introduction](https://www.springer.com/gp/book/9783319001180) - Presents a wide range of results in logic and computational complexity."
             ]
-        },
-
-        "Formal Method": {
-            "Lecture Notes": [
-                "[UW CSE505 18au Principles of PL](https://sites.google.com/cs.washington.edu/cse-505-18au/home) - Techniques for thinking crisply about programming languages, write some fascinating programs, and discuss various design tradeoffs."
-            ],
-            "Books": [
-                "[Chlipala. Formal Reasoning About Programs](http://adam.chlipala.net/frap/) - A book introducing both machine-checked proof with the Coq proof assistant and approaches to formal reasoning about program correctness.",
-                "[Pierce. Software Foundations Vol.1 Logical Foundation](https://softwarefoundations.cis.upenn.edu/lf-current/index.html) - Introduction to the mathematical underpinnings of reliable software with Coq Proof Assistant."
-            ]
         }
-    },
+  },
 
     "Algorithms": {
         "General": {
@@ -309,8 +339,8 @@
         "TCS Inspired": {
             "Lecture Videos Playlists": [
                 "[O'Donnell. CS Theory Toolkit](https://www.youtube.com/playlist?list=PLm3J0oaFux3ZYpFLwwrlv_EHH9wtH6pnX) - It covers a large number of the math/CS topics that you need to know for reading and doing research in Computer Science Theory - alternatively: [bilibili](https://www.bilibili.com/video/BV1Ry4y1e7zR)",
-		        "[Madhur Tulsiani. Mathematical Toolkit](https://home.ttic.edu/~madhurt/courses/toolkit2021/index.html) - Things prof. Madhur wish he knew in first year of grad school.",
-		        "[Harsha & Strivastava. Toolkit for Theoretical Computer Science. Tata Institute](https://www.tifr.res.in/~prahladh/teaching/2020-21/toolkit/)"
+		    "[Madhur Tulsiani. Mathematical Toolkit](https://home.ttic.edu/~madhurt/courses/toolkit2021/index.html) - Things prof. Madhur wish he knew in first year of grad school.",
+		    "[Harsha & Strivastava. Toolkit for Theoretical Computer Science. Tata Institute](https://www.tifr.res.in/~prahladh/teaching/2020-21/toolkit/)"
             ],
             "Lecture Notes": [
                 "[Zhou. A Theorist's Toolkit. Illinois](https://yuanz.web.illinois.edu/teaching/B609fa16/) - It covers a large number of the math/CS topics that you need to know for reading and doing research in Computer Science Theory.",
@@ -341,11 +371,6 @@
         },
         "Transition To Pure Rigour Math": [
             "Velleman. How to Prove it: A Structured Approach. - It transitions from solving problems to proving theorems by teaching them the techniques needed to read and write proofs."
-        ],
-        "Type Theory": [
-            "[Daniel Gratzer. learn-type-theory](https://github.com/jozefg/learn-tt) - A collection of resources for learning type theory and type theory adjacent fields.",
-            "[Type Theory in nLab](https://ncatlab.org/nlab/show/type+theory)",
-            "[Infinity-Type-Cafe. ∞-type Café Summer School](https://infinity-type-cafe.github.io/ntype-cafe-summer-school/) - A summer school on type theory (written in Chinese)"
         ]
     },
 

--- a/big_list_builder/source.json
+++ b/big_list_builder/source.json
@@ -106,6 +106,16 @@
             "Books": [
                 "[Pudlák. Logical Foundations of Mathematics and Computational Complexity: A Gentle Introduction](https://www.springer.com/gp/book/9783319001180) - Presents a wide range of results in logic and computational complexity."
             ]
+        },
+
+        "Formal Method": {
+            "Lecture Notes": [
+                "[UW CSE505 18au Principles of PL](https://sites.google.com/cs.washington.edu/cse-505-18au/home) - Techniques for thinking crisply about programming languages, write some fascinating programs, and discuss various design tradeoffs."
+            ],
+            "Books": [
+                "[Chlipala. Formal Reasoning About Programs](http://adam.chlipala.net/frap/) - A book introducing both machine-checked proof with the Coq proof assistant and approaches to formal reasoning about program correctness.",
+                "[Pierce. Software Foundations Vol.1 Logical Foundation](https://softwarefoundations.cis.upenn.edu/lf-current/index.html) - Introduction to the mathematical underpinnings of reliable software with Coq Proof Assistant."
+            ]
         }
     },
 
@@ -299,8 +309,8 @@
         "TCS Inspired": {
             "Lecture Videos Playlists": [
                 "[O'Donnell. CS Theory Toolkit](https://www.youtube.com/playlist?list=PLm3J0oaFux3ZYpFLwwrlv_EHH9wtH6pnX) - It covers a large number of the math/CS topics that you need to know for reading and doing research in Computer Science Theory - alternatively: [bilibili](https://www.bilibili.com/video/BV1Ry4y1e7zR)",
-		"[Madhur Tulsiani. Mathematical Toolkit](https://home.ttic.edu/~madhurt/courses/toolkit2021/index.html) - Things prof. Madhur wish he knew in first year of grad school.",
-		"[Harsha & Strivastava. Toolkit for Theoretical Computer Science. Tata Institute](https://www.tifr.res.in/~prahladh/teaching/2020-21/toolkit/)"
+		        "[Madhur Tulsiani. Mathematical Toolkit](https://home.ttic.edu/~madhurt/courses/toolkit2021/index.html) - Things prof. Madhur wish he knew in first year of grad school.",
+		        "[Harsha & Strivastava. Toolkit for Theoretical Computer Science. Tata Institute](https://www.tifr.res.in/~prahladh/teaching/2020-21/toolkit/)"
             ],
             "Lecture Notes": [
                 "[Zhou. A Theorist's Toolkit. Illinois](https://yuanz.web.illinois.edu/teaching/B609fa16/) - It covers a large number of the math/CS topics that you need to know for reading and doing research in Computer Science Theory.",
@@ -331,6 +341,11 @@
         },
         "Transition To Pure Rigour Math": [
             "Velleman. How to Prove it: A Structured Approach. - It transitions from solving problems to proving theorems by teaching them the techniques needed to read and write proofs."
+        ],
+        "Type Theory": [
+            "[Daniel Gratzer. learn-type-theory](https://github.com/jozefg/learn-tt) - A collection of resources for learning type theory and type theory adjacent fields.",
+            "[Type Theory in nLab](https://ncatlab.org/nlab/show/type+theory)",
+            "[Infinity-Type-Cafe. ∞-type Café Summer School](https://infinity-type-cafe.github.io/ntype-cafe-summer-school/) - A summer school on type theory (written in Chinese)"
         ]
     },
 


### PR DESCRIPTION
Add Logic - Formal Method, Math/Logic Preliminaries - Type Theory.
Not sure if they are correctly classified.

Restrictions:
- Formal Method currently includes only Coq-related materials. For other proof assistants (Lean, Agda, ...) , you can check out the links in Type Theory part. (See [learn-tt](https://github.com/jozefg/learn-tt) / [∞-type Café Summer School](https://infinity-type-cafe.github.io/ntype-cafe-summer-school/) )
- Formal Method, Type Theory may also be labeled as "Programming Language Theory".